### PR TITLE
fix: change export type to common js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-import Okra from './dist/bundle'
-
-export default Okra
+/* eslint-disable no-undef */
+const Okra = require("./dist/bundle");
+module.exports = Okra;


### PR DESCRIPTION
Hi, 

I am making a request to change the export type to use common js. I noticed the current implementation breaks when I try to use this package with next.js 

This will also work with all other implementations. 

Please take a look, thank you!